### PR TITLE
chore: remove email from contact page for privacy

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -21,7 +21,6 @@
           <h1>Contact</h1>
           <p>We'd love to hear from you. Use the form to send a message — sending is a placeholder for now and will be wired up later.</p>
           <ul class="contact-meta">
-            <li>Email: <a href="mailto:hello@hostileadmin.com">hello@hostileadmin.com</a></li>
             <li>Response time: Typically within a few days</li>
           </ul>
         </div>


### PR DESCRIPTION
Summary: Remove email from contact page for privacy.

This PR removes the visible mailto link from public/contact.html to avoid exposing an email address in the public site.

Files changed:
- public/contact.html (email list item removed)

No backend or build changes included.
