### PR TITLE
chore: remove Privacy link from contact footer

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -60,9 +60,9 @@
   </main>
 
   <footer class="site-footer">
-    <div class="container footer-inner">
+      <div class="container footer-inner">
       <div>© <span id="year"></span> The Millers</div>
-      <div class="footer-links"><a href="/privacy.html">Privacy</a> · <a href="/contact.html">Contact</a></div>
+      <div class="footer-links"><a href="/contact.html">Contact</a></div>
     </div>
   </footer>
 


### PR DESCRIPTION
Summary: Remove Privacy link from contact footer.

This pull request removes the 'Privacy' link from the footer on public/contact.html so the page only shows a Contact link.

Files changed:
- public/contact.html (footer: removed Privacy link)
