### PR TITLE
Add hostileadmin blog to index

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,10 @@
         <div class="sites-section">
           <h2>Our Other Projects</h2>
           <div class="site-links">
+            <a href="https://blog.hostileadmin.com" class="site-card">
+              <strong>hostileadmin blog</strong>
+              <span>Technical posts, tutorials, and project updates</span>
+            </a>
             <a href="https://www.vtmproperties.com" class="site-card">
               <strong>VTM Properties</strong>
               <span>Property management and real estate services</span>


### PR DESCRIPTION
Adds the hostileadmin blog site card to the home page's 'Our Other Projects' section.