### PR TITLE
Add hostileadmin blog to index and sites

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,14 +36,10 @@
           <div class="site-links">
             <a href="https://blog.hostileadmin.com" class="site-card">
               <strong>hostileadmin blog</strong>
-              <span>Technical posts, tutorials, and project updates</span>
-            </a>
-            <a href="https://www.vtmproperties.com" class="site-card">
-              <strong>VTM Properties</strong>
-              <span>Property management and real estate services</span>
+              <span>Technical posts and tutorials</span>
             </a>
             <a href="https://creekpaddler.com" class="site-card">
-              <strong>Creek Paddler</strong>
+              <strong>creek paddler</strong>
               <span>Outdoor adventures and kayaking stories</span>
             </a>
           </div>

--- a/public/sites.html
+++ b/public/sites.html
@@ -31,9 +31,6 @@
           <p>creekpaddler.com</p>
         </li>
         <li>
-          <p>www.vtmproperties.com</p>
-        </li>
-        <li>
           <p>blog.hostileadmin.com</p>
         </li>
       </ul>


### PR DESCRIPTION
Adds blog.hostileadmin.com to the Sites page list and a matching site-card on the index page (lowercase title).