### PR TITLE
Add Cloudflare Turnstile spam protection to contact form

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -56,9 +56,9 @@
             <textarea id="message" name="message" rows="6" required placeholder="Write your message here"></textarea>
           </div>
 
-          <!-- Cloudflare Turnstile widget -->
+          <!-- Cloudflare Turnstile widget  -->
           <div class="form-row">
-            <div class="cf-turnstile" data-sitekey="YOUR_SITE_KEY" data-callback="onTurnstileSuccess"></div>
+            <div class="cf-turnstile" data-sitekey="0x4AAAAAACBBiMlY4RoankgC" data-callback="onTurnstileSuccess"></div>
           </div>
 
           <div class="form-row form-actions">

--- a/public/contact.html
+++ b/public/contact.html
@@ -6,6 +6,8 @@
   <title>Contact — The Millers</title>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="/style.css">
+  <!-- Cloudflare Turnstile snippet -->
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -54,11 +56,17 @@
             <textarea id="message" name="message" rows="6" required placeholder="Write your message here"></textarea>
           </div>
 
+          <!-- Cloudflare Turnstile widget -->
+          <div class="form-row">
+            <div class="cf-turnstile" data-sitekey="YOUR_SITE_KEY" data-callback="onTurnstileSuccess"></div>
+          </div>
+
           <div class="form-row form-actions">
-            <button id="send" class="cta" type="submit">Send message</button>
+            <button id="send" class="cta" type="submit" disabled>Send message</button>
             <button type="reset" class="muted" style="margin-left:12px">Reset</button>
           </div>
 
+          <input id="cf-token" type="hidden" name="cf-turnstile-response">
           <div id="form-status" role="status" aria-live="polite" class="form-status"></div>
         </form>
       </div>
@@ -93,6 +101,13 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
 
+    // Cloudflare Turnstile callback function
+    function onTurnstileSuccess(token) {
+      document.getElementById('cf-token').value = token;
+      document.getElementById('send').disabled = false;
+      console.log('Turnstile verification successful');
+    }
+
     // Enhanced contact form with worker integration
     document.getElementById('contact-form').addEventListener('submit', async function(evt){
       evt.preventDefault();
@@ -107,6 +122,7 @@
       const email = formData.get('email').trim();
       const subject = formData.get('subject').trim();
       const message = formData.get('message').trim();
+      const turnstileToken = formData.get('cf-turnstile-response');
       
       // Basic client-side validation
       if (!name || !email || !subject || !message) {
@@ -116,6 +132,11 @@
       
       if (!isValidEmail(email)) {
         showStatus('Please enter a valid email address.', 'error');
+        return;
+      }
+
+      if (!turnstileToken) {
+        showStatus('Please complete the security verification.', 'error');
         return;
       }
       


### PR DESCRIPTION
Implements Cloudflare Turnstile verification on the contact form to prevent spam submissions. 

## Changes:
- Added Turnstile script and widget to contact form
- Submit button disabled until verification completes
- Client-side validation for Turnstile token
- Tested and validated on preview domain

## Testing:
- Turnstile widget loads correctly
- Verification challenge completes successfully  
- Submit button enables after verification
- Token validation prevents submission without verification

Ready for production deployment.